### PR TITLE
Remove unused pgpool shutdown handling

### DIFF
--- a/services/orchestrator/main.py
+++ b/services/orchestrator/main.py
@@ -184,9 +184,6 @@ async def startup_event():
 
 @app.on_event("shutdown")
 async def shutdown_event():
-    global _pgpool
-    if _pgpool:
-        _pgpool.closeall()
     task: asyncio.Task = app.state.task
     task.cancel()
     try:


### PR DESCRIPTION
## Summary
- remove unused `_pgpool` shutdown cleanup in orchestrator service

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'gateway', ModuleNotFoundError: No module named 'dowhy', SyntaxError in tests/test_orchestrator.py)


------
https://chatgpt.com/codex/tasks/task_b_68991e5c77488330b459d05049360f58