### PR TITLE
Return index count in vector service response

### DIFF
--- a/services/vector_search/main.py
+++ b/services/vector_search/main.py
@@ -140,7 +140,10 @@ async def index_documents(documents: List[Document], api_key: str = Security(get
         if data_to_load:
             index.load(data_to_load, id_field="id")
             logger.info(f"Successfully indexed {len(data_to_load)} documents.")
-        return {"message": f"Successfully indexed {len(data_to_load)} documents."}
+        return {
+            "indexed": len(data_to_load),
+            "message": f"Successfully indexed {len(data_to_load)} documents."
+        }
     except Exception as e:
         logger.error(f"Error indexing documents: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- include indexed document count in vector search `/index` response

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'redisvl'; ValueError: API_KEY environment variable not set)*
- `pre-commit run --files services/vector_search/main.py` *(fails: InvalidConfigError: did not find expected key)*

------
https://chatgpt.com/codex/tasks/task_b_68994f1984688330855174d399748983